### PR TITLE
feat: :sparkles: Add custom icons for interior & exterior 360

### DIFF
--- a/apps/demo-wc/index.html
+++ b/apps/demo-wc/index.html
@@ -35,7 +35,7 @@
           />
         </cc-webplayer-custom-media>
 
-        <cc-webplayer-icon name="TIRESPIN">
+        <cc-webplayer-icon name="UI_360_PLAY">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"

--- a/apps/docs/docs/advanced_customisation/icons.mdx
+++ b/apps/docs/docs/advanced_customisation/icons.mdx
@@ -84,7 +84,10 @@ type WebPlayerIconName =
   | "UI_PLAY" // Play video
   | "UI_PLUS" // Increase zoom
   | "UI_REDUCE" // Reducing an extended view
-  | "UI_360" // 360-degree view
+  | "UI_360" // Exterior 360 view
+  | "UI_360_PLAY" // Play exterior 360
+  | "UI_INTERIOR_360" // Interior 360 view
+  | "UI_INTERIOR_360_PLAY" // Play interior 360 view
   | "UI_VOLUME" // Video volume
   | "UI_VOLUME_OFF" // Muted video
   | "CONTROLS_PREV" // Go to previous media

--- a/packages/core-ui/src/components/icons/Exterior360PlayIcon.tsx
+++ b/packages/core-ui/src/components/icons/Exterior360PlayIcon.tsx
@@ -1,0 +1,23 @@
+import CustomizableIcon from "../atoms/CustomizableIcon";
+
+type Props = { className?: string };
+
+const Exterior360PlayIcon: React.FC<Props> = ({ className }) => {
+  return (
+    <CustomizableIcon className={className} customizationKey="UI_360_PLAY">
+      <svg
+        className={className}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polygon points="6 3 20 12 6 21 6 3" />
+      </svg>
+    </CustomizableIcon>
+  );
+};
+
+export default Exterior360PlayIcon;

--- a/packages/core-ui/src/components/icons/Interior360PlayIcon.tsx
+++ b/packages/core-ui/src/components/icons/Interior360PlayIcon.tsx
@@ -1,0 +1,26 @@
+import CustomizableIcon from "../atoms/CustomizableIcon";
+
+type Props = { className?: string };
+
+const Interior360PlayIcon: React.FC<Props> = ({ className }) => {
+  return (
+    <CustomizableIcon
+      className={className}
+      customizationKey="UI_INTERIOR_360_PLAY"
+    >
+      <svg
+        className={className}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polygon points="6 3 20 12 6 21 6 3" />
+      </svg>
+    </CustomizableIcon>
+  );
+};
+
+export default Interior360PlayIcon;

--- a/packages/core-ui/src/components/molecules/web_player_elements/InteriorThreeSixtyElement.tsx
+++ b/packages/core-ui/src/components/molecules/web_player_elements/InteriorThreeSixtyElement.tsx
@@ -12,8 +12,8 @@ import { CustomizableItem } from "../../../types/customizable_item";
 import { createThrottleDebounce } from "../../../utils/debounce";
 import { convertPannellumHfovToBidirectionalSteppedScale } from "../../../utils/math";
 import { cn } from "../../../utils/style";
+import Interior360PlayIcon from "../../icons/Interior360PlayIcon";
 import InteriorThreeSixtyIcon from "../../icons/InteriorThreeSixtyIcon";
-import PlayIcon from "../../icons/PlayIcon";
 import ErrorTemplate from "../../template/ErrorTemplate";
 import Button from "../../ui/Button";
 
@@ -45,10 +45,10 @@ const InteriorThreeSixtyElementLoadControls: React.FC<
   return (
     <div className="pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-y-4">
       <div className="pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-y-4 bg-foreground/35">
-        <InteriorThreeSixtyIcon className="size-20 text-primary-light" />
+        <InteriorThreeSixtyIcon className="text-primary-light size-20" />
 
         <Button color="neutral" shape="icon" onClick={loadScene}>
-          <PlayIcon className="size-full" />
+          <Interior360PlayIcon className="size-full" />
         </Button>
 
         <div
@@ -188,7 +188,7 @@ const InteriorThreeSixtyElementInteractive: React.FC<
       >
         <div
           className={cn(
-            "size-full duration-details",
+            "duration-details size-full",
             isShowingDetails ? "scale-105" : "scale-100"
           )}
         >

--- a/packages/core-ui/src/components/molecules/web_player_elements/ThreeSixtyElement.tsx
+++ b/packages/core-ui/src/components/molecules/web_player_elements/ThreeSixtyElement.tsx
@@ -8,7 +8,7 @@ import { CustomizableItem } from "../../../types/customizable_item";
 import { clamp } from "../../../utils/math";
 import { cn } from "../../../utils/style";
 import CdnImage from "../../atoms/CdnImage";
-import PlayIcon from "../../icons/PlayIcon";
+import Exterior360PlayIcon from "../../icons/Exterior360PlayIcon";
 import ThreeSixtyIcon from "../../icons/ThreeSixtyIcon";
 import ErrorTemplate from "../../template/ErrorTemplate";
 import Button from "../../ui/Button";
@@ -444,7 +444,7 @@ const ThreeSixtyElementInteractive: React.FC<ThreeSixtyElementProps> = ({
     <div ref={containerRef} className="cursor-ew-resize">
       {/* Scroller is element larger than the image to capture scroll event and then, make the 360 spin */}
       {/* NOTE: ImageElement is within so that it can capture events first */}
-      <div ref={scrollerRef} className="overflow-x-scroll no-scrollbar">
+      <div ref={scrollerRef} className="no-scrollbar overflow-x-scroll">
         <div className="sticky left-0 top-0">
           {/* Flip book (Ensures image are already in the DOM) */}
           {images.map(image => (
@@ -542,10 +542,10 @@ const ThreeSixtyElementPlaceholder: React.FC<
         onLoad={onPlaceholderImageLoaded}
       />
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-y-4 bg-foreground/35">
-        <ThreeSixtyIcon className="size-20 text-primary-light" />
+        <ThreeSixtyIcon className="text-primary-light size-20" />
 
         <Button color="neutral" shape="icon" onClick={fetchSpinImages}>
-          <PlayIcon className="size-full" />
+          <Exterior360PlayIcon className="size-full" />
         </Button>
 
         <div

--- a/packages/core/src/types/WebPlayerIcon.props.ts
+++ b/packages/core/src/types/WebPlayerIcon.props.ts
@@ -11,8 +11,10 @@ export type WebPlayerIconName =
   | "UI_PLAY" // Play video
   | "UI_PLUS" // Increase zoom
   | "UI_REDUCE" // Reducing an extended view
-  | "UI_360" // 360-degree view
-  | "UI_INTERIOR_360" // interior 360 view
+  | "UI_360" // Exterior 360 view
+  | "UI_360_PLAY" // Play exterior 360
+  | "UI_INTERIOR_360" // Interior 360 view
+  | "UI_INTERIOR_360_PLAY" // Play interior 360 view
   | "UI_VOLUME" // Video volume
   | "UI_VOLUME_OFF" // Muted video
   | "CONTROLS_PREV" // Go to previous media


### PR DESCRIPTION
# Description

Add the possibility to customize the icons of an interior & exterior 360.

# Checklist

- [x] Features are complete and working
- [x] Changes do not produce side effects
- [x] Code style and best practices are followed
- [x] Code is clean
- [x] Documentation is complete
- [x] Self-review is done
- [x] New and existing tests pass locally
- [x] Application successfully builds locally
- [x] Changes generate no new warnings
- [x] Changelog updated
