### PR TITLE
feat: :sparkles: Add hot spots types with styling capabilities

### DIFF
--- a/apps/docs/docs/styles.md
+++ b/apps/docs/docs/styles.md
@@ -6,18 +6,20 @@ sidebar_position: 4
 
 You can customize the WebPlayer color & roundness with CSS Variables
 
-| CSS Variable                        | Description                        | Default Value     |
-| ----------------------------------- | ---------------------------------- | ----------------- |
-| `--cc-webplayer-background`         | Background color (contrast texts)  | `0 0% 100%`       |
-| `--cc-webplayer-foreground`         | Foreground color (text color)      | `240 10% 3.9%`    |
-| `--cc-webplayer-primary`            | Primary color (buttons)            | `216 100% 52%`    |
-| `--cc-webplayer-primary-foreground` | Foreground color for primary items | `--cc-background` |
-| `--cc-webplayer-primary-light`      | Alternative to primary if too dark | `--cc-primary`    |
-| `--cc-webplayer-neutral`            | Neutral color                      | `0 0% 39%`        |
-| `--cc-webplayer-neutral-foreground` | Foreground color for neutral items | `--cc-foreground` |
-| `--cc-webplayer-radius-ui`          | UI element Border radius (buttons) | `16px`            |
-| `--cc-webplayer-radius-carrousel`   | Carrousel border radius            | `0`               |
-| `--cc-webplayer-radius-gallery`     | Gallery medias border radius       | `0`               |
+| CSS Variable                           | Description                        | Default Value     |
+| -------------------------------------- | ---------------------------------- | ----------------- |
+| `--cc-webplayer-background`            | Background color (contrast texts)  | `0 0% 100%`       |
+| `--cc-webplayer-foreground`            | Foreground color (text color)      | `240 10% 3.9%`    |
+| `--cc-webplayer-primary`               | Primary color (buttons)            | `216 100% 52%`    |
+| `--cc-webplayer-primary-foreground`    | Foreground color for primary items | `--cc-background` |
+| `--cc-webplayer-primary-light`         | Alternative to primary if too dark | `--cc-primary`    |
+| `--cc-webplayer-neutral`               | Neutral color                      | `0 0% 39%`        |
+| `--cc-webplayer-neutral-foreground`    | Foreground color for neutral items | `--cc-foreground` |
+| `--cc-webplayer-hotspot-damage-color`  | Color for damage hotspots          | `37 89% 52%`      |
+| `--cc-webplayer-hotspot-feature-color` | Color for feature hotspots         | `--cc-primary`    |
+| `--cc-webplayer-radius-ui`             | UI element Border radius (buttons) | `16px`            |
+| `--cc-webplayer-radius-carrousel`      | Carrousel border radius            | `0`               |
+| `--cc-webplayer-radius-gallery`        | Gallery medias border radius       | `0`               |
 
 ## Examples
 
@@ -27,6 +29,8 @@ You can insert CSS variables in your style files
 :root {
   --cc-webplayer-primary: 262 88% 58%;
   --cc-webplayer-radius-ui: 14px;
+  --cc-webplayer-hotspot-damage-color: 0 69% 63%;
+  --cc-webplayer-hotspot-feature-color: 211 100% 40%;
 }
 ```
 
@@ -37,6 +41,8 @@ Or directly in your HTML
   cc-webplayer {
     --cc-webplayer-primary: 262 88% 58%;
     --cc-webplayer-radius-ui: 14px;
+    --cc-webplayer-hotspot-damage-color: 0 69% 63%;
+    --cc-webplayer-hotspot-feature-color: 211 100% 40%;
   }
 </style>
 ```

--- a/packages/core-ui/dev/index.dev.css
+++ b/packages/core-ui/dev/index.dev.css
@@ -12,4 +12,7 @@
   /* --cc-webplayer-radius-ui: 0.55rem; */
   /* --cc-webplayer-radius-carrousel: 0.8rem; */
   /* --cc-webplayer-radius-gallery: 0.4rem; */
+
+  /* --cc-webplayer-hotspot-damage-color: 0 69% 63%; */
+  /* --cc-webplayer-hotspot-feature-color: 211 100% 40%; */
 }

--- a/packages/core-ui/src/WebPlayer.tsx
+++ b/packages/core-ui/src/WebPlayer.tsx
@@ -330,6 +330,10 @@ const WebPlayer: ReactFC<ReactPropsWithChildren<WebPlayerProps>> = ({
               "--radius-ui": "var(--cc-webplayer-radius-ui, 16px)",
               "--radius-carrousel": "var(--cc-webplayer-radius-carrousel, 0)",
               "--radius-gallery": "var(--cc-webplayer-radius-gallery, 0)",
+              "--hotspot-damage-color":
+                "hsl(var(--cc-webplayer-hotspot-damage-color, 37 89% 52%))",
+              "--hotspot-feature-color":
+                "hsl(var(--cc-webplayer-hotspot-feature-color, var(--primary)))",
             } as React.CSSProperties
           }
         >

--- a/packages/core-ui/src/components/icons/WarningIcon.tsx
+++ b/packages/core-ui/src/components/icons/WarningIcon.tsx
@@ -1,0 +1,27 @@
+import CustomizableIcon from "../atoms/CustomizableIcon";
+
+type Props = { className?: string };
+
+const WarningIcon: React.FC<Props> = ({ className }) => {
+  return (
+    <CustomizableIcon className={className} customizationKey="UI_WARNING">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" x2="12" y1="8" y2="12" />
+        <line x1="12" x2="12.01" y1="16" y2="16" />
+      </svg>
+    </CustomizableIcon>
+  );
+};
+
+export default WarningIcon;

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -7,6 +7,7 @@ import { useCustomizationContext } from "../../providers/CustomizationContext";
 import { useGlobalContext } from "../../providers/GlobalContext";
 import { cn } from "../../utils/style";
 import ImageIcon from "../icons/ImageIcon";
+import WarningIcon from "../icons/WarningIcon";
 
 type HotspotProps = {
   hotspot: HotspotType;
@@ -24,7 +25,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
   item,
   analyticsValue,
 }) => {
-  const { title, icon, description, position, detail } = hotspot;
+  const { title, icon, description, position, detail, type } = hotspot;
   const { emitAnalyticsEvent } = useGlobalContext();
   const {
     extendMode,
@@ -76,6 +77,8 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
 
   const DefaultIcon = withImage ? (
     <ImageIcon className="size-4" />
+  ) : type === "damage" ? (
+    <WarningIcon className="size-4" />
   ) : (
     <div className="size-1" />
   );
@@ -107,6 +110,20 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
     setOver(false);
   }, [over, setOver]);
 
+  // Determine which CSS variable to use based on hotspot type
+  const getHotspotColorVariable = useCallback(() => {
+    if (type === "damage") {
+      return "var(--hotspot-damage-color)";
+    }
+    if (type === "feature") {
+      return "var(--hotspot-feature-color)";
+    }
+    // Default: if no type, use feature color with fallback to primary
+    return "var(--hotspot-feature-color)";
+  }, [type]);
+
+  const hotspotColorVariable = getHotspotColorVariable();
+
   return (
     <div
       className={cn(
@@ -124,10 +141,12 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       <div
         // Hoverable icon
         className="relative flex items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground"
+        style={{ backgroundColor: hotspotColorVariable }}
       >
         <div
           // Ping animation
-          className="pointer-events-none absolute -z-20 size-8 animate-hotspot-ping rounded-full border-2 border-background"
+          className="pointer-events-none absolute -z-20 size-8 animate-hotspot-ping rounded-full border-2 border-background bg-primary"
+          style={{ backgroundColor: hotspotColorVariable }}
         />
 
         {/* Use the icon from the config if available. Else, replace it if needed */}

--- a/packages/core/src/types/composition.ts
+++ b/packages/core/src/types/composition.ts
@@ -4,6 +4,7 @@ export type Hotspot = {
   title: string;
   icon?: string;
   description?: string;
+  type?: "damage" | "feature";
   position: {
     x: number;
     y: number;


### PR DESCRIPTION
# Description

Added hot spots types (feature and damage). Added css vars to color hotspots based on their types.

# Checklist

- [x] Features are complete and working
- [x] Changes do not produce side effects
- [x] Code style and best practices are followed
- [x] Code is clean
- [x] Documentation is complete
- [x] Self-review is done
- [x] New and existing tests pass locally
- [x] Application successfully builds locally
- [x] Changes generate no new warnings
- [x] Changelog updated
