### PR TITLE
fix: :bug: Damage hotspots icons fix

### DIFF
--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -76,9 +76,11 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
   const withText = !!title || !!description;
 
   const DefaultIcon = withImage ? (
-    <ImageIcon className="size-4" />
-  ) : type === "damage" ? (
-    <WarningIcon className="size-4" />
+    type === "damage" ? (
+      <WarningIcon className="size-4" />
+    ) : (
+      <ImageIcon className="size-4" />
+    )
   ) : (
     <div className="size-1" />
   );


### PR DESCRIPTION
# Description

Fix for damage hotspots, where icon is not shown without detailed image available

# Checklist

- [x] Features are complete and working
- [x] Changes do not produce side effects
- [x] Code style and best practices are followed
- [x] Code is clean
- [x] Documentation is complete
- [x] Self-review is done
- [x] New and existing tests pass locally
- [x] Application successfully builds locally
- [x] Changes generate no new warnings
- [x] Changelog updated
