### PR TITLE
fix: 🐛 Update aspect ratio class for error and loading

### DIFF
--- a/packages/core-ui/src/components/organisms/WebPlayerContainer.tsx
+++ b/packages/core-ui/src/components/organisms/WebPlayerContainer.tsx
@@ -221,7 +221,7 @@ const WebPlayerContainer: React.FC<WebPlayerContainerProps> = () => {
   if (error) {
     return (
       <ErrorTemplate
-        className="aspect-square text-foreground/70"
+        className="aspect-video text-foreground/70"
         text="Player could not be loaded"
       />
     );
@@ -229,7 +229,7 @@ const WebPlayerContainer: React.FC<WebPlayerContainerProps> = () => {
 
   if (!isSuccess) {
     return (
-      <div className="flex aspect-square size-full flex-col items-center justify-center gap-y-4">
+      <div className="flex aspect-video size-full flex-col items-center justify-center gap-y-4">
         <div className="animate-pulse text-xl">Loading Player</div>
         <Spinner color="foreground" />
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the web player's fallback UI layout to use video aspect ratio instead of square format for error and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->