### PR TITLE
feat: ✨ Disable pinch-zoom

### DIFF
--- a/packages/core-ui/src/components/atoms/ZoomableCdnImage.tsx
+++ b/packages/core-ui/src/components/atoms/ZoomableCdnImage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 
+import { MAX_SMALL_MEDIA_QUERY } from "../../const/browser";
 import { MAX_ZOOM } from "../../const/zoom";
 import { useControlsContext } from "../../providers/ControlsContext";
 import { easeOut } from "../../utils/animation";
@@ -437,6 +438,11 @@ const ZoomableCdnImage: React.FC<ZoomableCdnImageProps> = ({
 
     const touchStartXYmapRef = touchStartXYmap.current;
 
+    // Pinch-zoom is disabled on mobile: the zoom controls are hidden there
+    // (`max-small:hidden`), so allowing pinch would only surface the close
+    // button without a usable zoom. We let native page pinch-zoom happen instead.
+    const isMobile = window.matchMedia(MAX_SMALL_MEDIA_QUERY).matches;
+
     const onTouchStart = (e: TouchEvent) => {
       for (let i = 0; i < e.changedTouches.length; i++) {
         const touch = e.changedTouches[i];
@@ -480,6 +486,12 @@ const ZoomableCdnImage: React.FC<ZoomableCdnImageProps> = ({
       }
       // 2 fingers => zoom
       else if (nbrTouches === 2) {
+        // Pinch-zoom disabled on mobile (zoom controls are hidden there).
+        // Bail before preventDefault so native page pinch-zoom is allowed.
+        if (isMobile) {
+          return;
+        }
+
         e.preventDefault(); // Prevents native page zooming
 
         const [touch1, touch2] = e.touches;

--- a/packages/core-ui/src/components/atoms/ZoomableCdnImage.tsx
+++ b/packages/core-ui/src/components/atoms/ZoomableCdnImage.tsx
@@ -438,11 +438,6 @@ const ZoomableCdnImage: React.FC<ZoomableCdnImageProps> = ({
 
     const touchStartXYmapRef = touchStartXYmap.current;
 
-    // Pinch-zoom is disabled on mobile: the zoom controls are hidden there
-    // (`max-small:hidden`), so allowing pinch would only surface the close
-    // button without a usable zoom. We let native page pinch-zoom happen instead.
-    const isMobile = window.matchMedia(MAX_SMALL_MEDIA_QUERY).matches;
-
     const onTouchStart = (e: TouchEvent) => {
       for (let i = 0; i < e.changedTouches.length; i++) {
         const touch = e.changedTouches[i];
@@ -486,9 +481,12 @@ const ZoomableCdnImage: React.FC<ZoomableCdnImageProps> = ({
       }
       // 2 fingers => zoom
       else if (nbrTouches === 2) {
-        // Pinch-zoom disabled on mobile (zoom controls are hidden there).
-        // Bail before preventDefault so native page pinch-zoom is allowed.
-        if (isMobile) {
+        // Pinch-zoom is disabled on mobile: the zoom controls are hidden there
+        // (`max-small:hidden`), so allowing pinch would only surface the close
+        // button without a usable zoom. Evaluated at event time (not cached) so
+        // it stays correct across viewport/orientation changes. We bail before
+        // preventDefault so native page pinch-zoom is allowed instead.
+        if (window.matchMedia(MAX_SMALL_MEDIA_QUERY).matches) {
           return;
         }
 

--- a/packages/core-ui/src/const/browser.ts
+++ b/packages/core-ui/src/const/browser.ts
@@ -1,1 +1,8 @@
 export const RESIZE_TRANSITION_DURATION = 500;
+
+// Mirrors the `max-small` breakpoint defined in tailwind.config.ts
+// (BREAKPOINT_SMALL_PORTRAIT = 768, BREAKPOINT_SMALL_LANDSCAPE = 1024).
+// Used at runtime (via window.matchMedia) to keep JS behavior in sync with
+// the `max-small:` Tailwind utilities. Comma acts as the "or" combinator.
+export const MAX_SMALL_MEDIA_QUERY =
+  "(orientation: portrait) and (max-width: 767px), (orientation: landscape) and (max-width: 1023px)";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile touch gesture handling for image zoom. On small/mobile viewports the component now defers to the browser’s native pinch-to-zoom instead of applying its own zoom/pan behavior, preventing conflicts and restoring the expected pinch-zoom experience for mobile users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->