### PR TITLE
fix: 🐛 Update peer dependencies to support wider React versions

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -5,6 +5,12 @@
       "dependencies": ["@car-cutter/**"],
       "dependencyTypes": ["dev", "prod"],
       "policy": "sameRange"
+    },
+    {
+      "label": "Framework peer ranges must stay wide (publishable wrappers omit them; internal pkgs keep wide ranges - never pin/unify to installed version)",
+      "dependencies": ["next", "react", "react-dom", "vue"],
+      "dependencyTypes": ["peer"],
+      "isIgnored": true
     }
   ]
 }

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -14,7 +14,7 @@
     "pannellum-react": "^1.2.4"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=16.8"
   },
   "devDependencies": {
     "@car-cutter/eslint-config": "*",

--- a/packages/core-wc-react-16-17/package.json
+++ b/packages/core-wc-react-16-17/package.json
@@ -14,8 +14,8 @@
     "@r2wc/react-to-web-component": "^2.0.3"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@car-cutter/eslint-config": "*",

--- a/packages/webplayer-next/package.json
+++ b/packages/webplayer-next/package.json
@@ -47,9 +47,6 @@
   "dependencies": {
     "@car-cutter/react-webplayer": "*"
   },
-  "peerDependencies": {
-    "next": "16.2.6"
-  },
   "devDependencies": {
     "@car-cutter/eslint-config": "*",
     "@car-cutter/typescript-config": "*",

--- a/packages/webplayer-react/package.json
+++ b/packages/webplayer-react/package.json
@@ -45,10 +45,6 @@
     "lint": "eslint . --ext ts,tsx --max-warnings 0",
     "analyze": "vite-bundle-visualizer"
   },
-  "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
-  },
   "devDependencies": {
     "@car-cutter/core": "*",
     "@car-cutter/core-ui": "*",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded React compatibility across packages to support older versions (minimum >=16.8 instead of >=18), enabling broader framework compatibility
  * Removed strict peer dependency pinning for Next.js and React packages to provide greater version flexibility and reduce compatibility constraints
  * Updated dependency synchronization configuration to prevent automatic version enforcement on framework packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->