### PR TITLE
feat: ✨ Enhance inline expandable functionality for hotspots

### DIFF
--- a/packages/core-ui/dev/DevApp.tsx
+++ b/packages/core-ui/dev/DevApp.tsx
@@ -114,7 +114,7 @@ const DevApp: React.FC = () => {
       >
         <WebPlayer
           // compositionUrl="/composition_mock_1.json"
-          compositionUrl="https://cdn.car-cutter.com/gallery/1a7136e1b91c8898b5ceff1d7dcb85e41f77a17fa64f7267d60b0fd5e99005d2/TMBEP9PJ0P4089138/composition_v3.json"
+          compositionUrl="https://cdn.car-cutter.com/libs/web-player/v3/demos/composition_v3.json"
           // compositionUrl="https://cdn.car-cutter.com/libs/web-player/v3/demos/interior-360.json"
           // compositionUrl="https://cdn.car-cutter.com/libs/web-player/v3/demos/composition.json"
           //compositionUrl="https://cdn.car-cutter.com/gallery/7de693a6dd8379eb743f6093499bdd13fe76876f135ae9a08b7d9ecbfb7f8664/WAUZZZF34N1097219/composition_v3.json"

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Hotspot as HotspotType } from "@car-cutter/core";
 
+import {
+  HOTSPOT_EXPANDED_PANEL_WIDTH,
+  LARGE_MEDIA_QUERY,
+  SMALL_MEDIA_QUERY,
+} from "../../const/browser";
 import { useControlsContext } from "../../providers/ControlsContext";
 import { useCustomizationContext } from "../../providers/CustomizationContext";
 import { useGlobalContext } from "../../providers/GlobalContext";
@@ -19,6 +24,26 @@ type HotspotProps = {
 };
 type IconHotspotProps = HotspotProps & {
   analyticsValue: object;
+};
+
+// Mirrors the `w-72 max-w-[70vw] small:w-80 large:w-96` classes applied to the
+// inline detail panel when expanded. Used to pick the flip direction based on
+// the panel's *expanded* width (not the collapsed pill) so the expanded panel
+// stays within the media on whichever side it opens.
+const getExpandedPanelWidth = (): number => {
+  if (typeof window === "undefined") {
+    return HOTSPOT_EXPANDED_PANEL_WIDTH.base;
+  }
+
+  let width: number = HOTSPOT_EXPANDED_PANEL_WIDTH.base;
+  if (window.matchMedia(LARGE_MEDIA_QUERY).matches) {
+    width = HOTSPOT_EXPANDED_PANEL_WIDTH.large;
+  } else if (window.matchMedia(SMALL_MEDIA_QUERY).matches) {
+    width = HOTSPOT_EXPANDED_PANEL_WIDTH.small;
+  }
+
+  // Mirror the `max-w-[70vw]` cap on the expanded panel.
+  return Math.min(width, window.innerWidth * 0.7);
 };
 
 const IconHotspot: React.FC<IconHotspotProps> = ({
@@ -246,15 +271,26 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
         const hotspotRect = hotspotElement.getBoundingClientRect();
         const titleRect = titleElement.getBoundingClientRect();
 
-        const availableRight = containerRect.right - hotspotRect.left;
-        const availableLeft = hotspotRect.right - containerRect.left;
-        const titleWidth = titleRect.width;
+        // Measure available space from the hotspot dot's center, which is the
+        // anchor point of the panel (left-0 / right-0 of the dot-centered root).
+        // Using the same reference on both sides keeps the comparison symmetric.
+        const hotspotCenter = (hotspotRect.left + hotspotRect.right) / 2;
+        const availableRight = containerRect.right - hotspotCenter;
+        const availableLeft = hotspotCenter - containerRect.left;
+
+        // For hotspots that expand inline, decide the direction based on the
+        // panel's *expanded* width so the expanded detail fits the media too —
+        // not just the collapsed pill. The expanded width is always >= the pill
+        // width, so the chosen side fits both states (no flip on expand).
+        const requiredWidth = inlineExpandable
+          ? Math.max(titleRect.width, getExpandedPanelWidth())
+          : titleRect.width;
 
         let nextShouldFlip = false;
 
-        if (availableRight >= titleWidth) {
+        if (availableRight >= requiredWidth) {
           nextShouldFlip = false;
-        } else if (availableLeft >= titleWidth) {
+        } else if (availableLeft >= requiredWidth) {
           nextShouldFlip = true;
         } else {
           nextShouldFlip = availableLeft >= availableRight;
@@ -287,7 +323,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       }
       resizeObserver.disconnect();
     };
-  }, [withTitle, title, clickable, extendMode, withDetail]);
+  }, [withTitle, title, clickable, extendMode, withDetail, inlineExpandable]);
 
   // While collapsing, keep the panel laid out (wide + opaque) so the
   // description can retract smoothly before reverting to the title pill.
@@ -351,10 +387,10 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
           {/* Title row — vertically centered on the hotspot dot */}
           <div
             className={cn(
-              "relative flex items-center gap-1.5 bg-foreground py-1.5 text-background",
+              "relative flex items-center gap-1.5 border-[0.5px] border-[#64748B] bg-foreground py-1.5 text-background",
               panelMounted
                 ? cn(
-                    "z-10",
+                    "z-10 border-b-0",
                     // The corner under the hotspot icon matches the circle radius (size-7 = 28px ⇒ 14px)
                     shouldFlipTitle
                       ? "rounded-tl-[16px] rounded-tr-[14px] pl-3 pr-6 small:pr-7"
@@ -378,27 +414,8 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
             >
               {title}
             </div>
-            {clickable && (
-              <span
-                className="flex shrink-0"
-                style={
-                  inlineExpandable
-                    ? {
-                        // Two-phase motion: slide right first, then rotate down.
-                        // On collapse the order reverses (rotate up first, then
-                        // slide back) and runs a touch quicker.
-                        translate: expanded ? "5px 0" : "0 0",
-                        rotate: expanded ? "90deg" : "0deg",
-                        transition: expanded
-                          ? "translate 200ms ease, rotate 200ms ease"
-                          : "translate 150ms ease, rotate 150ms ease",
-                        transitionDelay: expanded
-                          ? "0ms, 180ms"
-                          : "120ms, 0ms",
-                      }
-                    : undefined
-                }
-              >
+            {clickable && !inlineExpandable && (
+              <span className="flex shrink-0">
                 <ArrowRightIcon className="size-5 shrink-0" />
               </span>
             )}
@@ -408,7 +425,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
           {inlineExpandable && (
             <div
               className={cn(
-                "absolute inset-x-0 top-full grid transition-[grid-template-rows] ease-out",
+                "absolute inset-x-0 top-[calc(100%-1px)] grid transition-[grid-template-rows] ease-out",
                 expanded ? "grid-rows-[1fr] duration-300" : "grid-rows-[0fr] duration-200"
               )}
               onTransitionEnd={event => {
@@ -425,7 +442,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
               <div className="min-h-0 overflow-hidden">
                 <div
                   className={cn(
-                    "max-h-[clamp(4rem,40vh,16rem)] overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] bg-foreground pb-2 pt-1.5 text-xs font-normal leading-relaxed text-background",
+                    "max-h-[clamp(4rem,40vh,16rem)] transform-gpu overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground py-2 text-xs font-normal leading-relaxed text-background",
                     // Align description start with the title text start
                     shouldFlipTitle ? "pl-3 pr-6 small:pr-7" : "pl-6 pr-3 small:pl-7"
                   )}

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -343,11 +343,12 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
   const hotspotContent = (
     <>
       <div
-        // Hoverable icon
-        className={cn(
-          "relative top-px flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground",
-          shouldFlipTitle ? "right-[-5px]" : "left-[-5px]"
-        )}
+        // Hoverable icon — kept centered on the hotspot coordinate (no relative
+        // x-offset) so the painted circle, the CSS :hover region that reveals the
+        // title, and the click hit-box are the exact same 28px area. A paint-only
+        // offset would shift the visible/hover circle off the click box, creating
+        // an edge sliver where hovering shows the title but clicking misses.
+        className="relative top-px flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground"
         style={{ backgroundColor: hotspotColorVariable }}
       >
         <div

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -26,6 +26,31 @@ type IconHotspotProps = HotspotProps & {
   analyticsValue: object;
 };
 
+const HOTSPOT_INTERACTION_EVENT = "car-cutter:inline-hotspot-interaction";
+
+type HotspotInteractionEvent = CustomEvent<{
+  sourceElement: HTMLElement;
+}>;
+
+const getRootEventTarget = (
+  element: HTMLElement | null
+): Document | ShadowRoot | null => {
+  const rootNode = element?.getRootNode();
+
+  if (!rootNode) {
+    return null;
+  }
+
+  if (
+    rootNode instanceof Document ||
+    (typeof ShadowRoot !== "undefined" && rootNode instanceof ShadowRoot)
+  ) {
+    return rootNode;
+  }
+
+  return null;
+};
+
 // Mirrors the `w-72 max-w-[70vw] small:w-80 large:w-96` classes applied to the
 // inline detail panel when expanded. Used to pick the flip direction based on
 // the panel's *expanded* width (not the collapsed pill) so the expanded panel
@@ -143,6 +168,21 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
     });
   }, [clearCollapseTimeout]);
 
+  const dispatchHotspotInteraction = useCallback(() => {
+    const rootElement = hotspotDivRef.current;
+    const eventTarget = getRootEventTarget(rootElement);
+
+    if (!rootElement || !eventTarget) {
+      return;
+    }
+
+    eventTarget.dispatchEvent(
+      new CustomEvent(HOTSPOT_INTERACTION_EVENT, {
+        detail: { sourceElement: rootElement },
+      })
+    );
+  }, []);
+
   useEffect(() => clearCollapseTimeout, [clearCollapseTimeout]);
 
   const DefaultIcon =
@@ -169,6 +209,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       if (expanded) {
         collapsePanel();
       } else {
+        dispatchHotspotInteraction();
         clearCollapseTimeout();
         setCollapsing(false);
         setExpanded(true);
@@ -187,8 +228,14 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
   const onMouseEnter = useCallback(() => {
     if (over) return;
     setOver(true);
+    dispatchHotspotInteraction();
     emitAnalyticsEventHotspotHovered();
-  }, [over, setOver, emitAnalyticsEventHotspotHovered]);
+  }, [
+    over,
+    setOver,
+    dispatchHotspotInteraction,
+    emitAnalyticsEventHotspotHovered,
+  ]);
 
   const onMouseLeave = useCallback(() => {
     if (!over) return;
@@ -201,27 +248,70 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       return;
     }
 
+    const rootElement = hotspotDivRef.current;
+    const pointerEventTarget = getRootEventTarget(rootElement);
+
+    if (!rootElement || !pointerEventTarget) {
+      return;
+    }
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         collapsePanel();
       }
     };
 
-    const handlePointerDown = (event: PointerEvent) => {
-      const rootElement = hotspotDivRef.current;
-      if (rootElement && !rootElement.contains(event.target as Node)) {
+    const handlePointerDown = (event: Event) => {
+      const eventPath = event.composedPath();
+      const isInsideHotspot =
+        eventPath.includes(rootElement) ||
+        rootElement.contains(event.target as Node);
+
+      if (!isInsideHotspot) {
         collapsePanel();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("pointerdown", handlePointerDown);
+    pointerEventTarget.addEventListener("pointerdown", handlePointerDown);
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("pointerdown", handlePointerDown);
+      pointerEventTarget.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [expanded, collapsePanel]);
+
+  useEffect(() => {
+    if (!inlineExpandable || !expanded) {
+      return;
+    }
+
+    const rootElement = hotspotDivRef.current;
+    const eventTarget = getRootEventTarget(rootElement);
+
+    if (!rootElement || !eventTarget) {
+      return;
+    }
+
+    const handleHotspotInteraction = (event: Event) => {
+      const interactionEvent = event as HotspotInteractionEvent;
+      if (interactionEvent.detail.sourceElement !== rootElement) {
+        collapsePanel();
+      }
+    };
+
+    eventTarget.addEventListener(
+      HOTSPOT_INTERACTION_EVENT,
+      handleHotspotInteraction
+    );
+
+    return () => {
+      eventTarget.removeEventListener(
+        HOTSPOT_INTERACTION_EVENT,
+        handleHotspotInteraction
+      );
+    };
+  }, [inlineExpandable, expanded, collapsePanel]);
 
   // Determine which CSS variable to use based on hotspot type
   const getHotspotColorVariable = useCallback(() => {

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -399,8 +399,8 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
                 : cn(
                     "rounded-t-full",
                     shouldFlipTitle
-                      ? "rounded-bl-full rounded-br-[10px] pl-2.5 pr-6 small:pl-3 small:pr-7"
-                      : "rounded-bl-[10px] rounded-br-full pl-6 pr-2.5 small:pl-7 small:pr-3"
+                      ? "rounded-b-full pl-2.5 pr-6 small:pl-3 small:pr-7"
+                      : "rounded-b-full pl-6 pr-2.5 small:pl-7 small:pr-3"
                   )
             )}
           >
@@ -426,14 +426,13 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
             <div
               className={cn(
                 "absolute inset-x-0 top-[calc(100%-1px)] grid transition-[grid-template-rows] ease-out",
-                expanded ? "grid-rows-[1fr] duration-300" : "grid-rows-[0fr] duration-200"
+                expanded
+                  ? "grid-rows-[1fr] duration-300"
+                  : "grid-rows-[0fr] duration-200"
               )}
               onTransitionEnd={event => {
                 // Once the description has fully retracted, revert to the pill
-                if (
-                  event.propertyName === "grid-template-rows" &&
-                  !expanded
-                ) {
+                if (event.propertyName === "grid-template-rows" && !expanded) {
                   clearCollapseTimeout();
                   setCollapsing(false);
                 }
@@ -444,7 +443,9 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
                   className={cn(
                     "max-h-[clamp(4rem,40vh,16rem)] transform-gpu overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground py-2 text-xs font-normal leading-relaxed text-background",
                     // Align description start with the title text start
-                    shouldFlipTitle ? "pl-3 pr-6 small:pr-7" : "pl-6 pr-3 small:pl-7"
+                    shouldFlipTitle
+                      ? "pl-3 pr-6 small:pr-7"
+                      : "pl-6 pr-3 small:pl-7"
                   )}
                 >
                   {description}

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -508,10 +508,10 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
           >
             <div
               className={cn(
-                "text-xs font-normal",
+                "font-normal",
                 panelMounted
-                  ? "min-w-0 flex-1 break-words font-medium"
-                  : "truncate"
+                  ? "min-w-0 flex-1 break-words text-[13px] font-medium"
+                  : "truncate text-xs"
               )}
             >
               {title}

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -366,7 +366,15 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       {withTitle && (
         <div
           className={cn(
-            "absolute top-[calc(50%+1px)] -z-10 -translate-y-1/2 transition-[opacity,transform] duration-200",
+            "absolute -z-10",
+            panelMounted
+              ? // Expanded: anchor the panel's top edge to the top of the hotspot dot
+                // (dot is size-7 = 28px with top-px ⇒ its top sits at 50% - 13px), so the
+                // panel grows downward from the hotspot instead of being centered on it.
+                // Only animate opacity here; the vertical anchor snaps with the width/padding
+                // when toggling so the transform doesn't slide the panel on collapse.
+                "top-[calc(50%-13px)] transition-opacity duration-200"
+              : "top-[calc(50%+1px)] -translate-y-1/2 transition-[opacity,transform] duration-200",
             panelMounted
               ? // Expanded: grow to a comfortable reading width, bounded by the media
                 "w-72 max-w-[70vw] small:w-80 large:w-96"
@@ -384,20 +392,23 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
           )}
           ref={titleRef}
         >
-          {/* Title row — vertically centered on the hotspot dot */}
+          {/* Title row — centered on the hotspot dot when collapsed; top-anchored when expanded */}
           <div
             className={cn(
-              "relative flex items-center gap-1.5 border-[0.5px] border-[#64748B] bg-foreground py-1.5 text-background",
+              "relative flex items-center gap-1.5 border-[0.5px] border-[#64748B] bg-foreground text-background",
               panelMounted
                 ? cn(
                     "z-10 border-b-0",
                     // The corner under the hotspot icon matches the circle radius (size-7 = 28px ⇒ 14px)
+                    // Match top padding to the horizontal padding; keep the bottom tight so the
+                    // description butts directly against the title to read as one panel.
+                    "px-6 pb-1.5 pt-6 small:px-7 small:pt-7",
                     shouldFlipTitle
-                      ? "rounded-tl-[16px] rounded-tr-[14px] pl-3 pr-6 small:pr-7"
-                      : "rounded-tl-[14px] rounded-tr-[16px] pl-6 pr-3 small:pl-7"
+                      ? "rounded-tl-[16px] rounded-tr-[14px]"
+                      : "rounded-tl-[14px] rounded-tr-[16px]"
                   )
                 : cn(
-                    "rounded-t-full",
+                    "rounded-t-full py-1.5",
                     shouldFlipTitle
                       ? "rounded-b-full pl-2.5 pr-6 small:pl-3 small:pr-7"
                       : "rounded-b-full pl-6 pr-2.5 small:pl-7 small:pr-3"
@@ -441,11 +452,9 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
               <div className="min-h-0 overflow-hidden">
                 <div
                   className={cn(
-                    "max-h-[clamp(4rem,40vh,16rem)] transform-gpu overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground py-2 text-xs font-normal leading-relaxed text-background",
-                    // Align description start with the title text start
-                    shouldFlipTitle
-                      ? "pl-3 pr-6 small:pr-7"
-                      : "pl-6 pr-3 small:pl-7"
+                    "max-h-[clamp(4rem,40vh,16rem)] transform-gpu overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground pb-6 pt-1.5 text-xxs font-normal leading-relaxed text-background small:pb-7",
+                    // Align description padding with the expanded title
+                    "px-6 small:px-7"
                   )}
                 >
                   {description}

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -453,7 +453,7 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
               <div className="min-h-0 overflow-hidden">
                 <div
                   className={cn(
-                    "max-h-[clamp(4rem,40vh,16rem)] transform-gpu overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground pb-6 pt-1.5 text-xxs font-normal leading-relaxed text-background small:pb-7",
+                    "max-h-[clamp(4rem,40vh,16rem)] overflow-y-auto overscroll-y-none whitespace-normal break-words rounded-b-[16px] border-x-[0.5px] border-b-[0.5px] border-[#64748B] bg-foreground pb-6 pt-1.5 text-xxs font-normal leading-relaxed text-background small:pb-7",
                     // Align description padding with the expanded title
                     "px-6 small:px-7"
                   )}

--- a/packages/core-ui/src/components/molecules/Hotspot.tsx
+++ b/packages/core-ui/src/components/molecules/Hotspot.tsx
@@ -81,20 +81,51 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
   const withDetail = withImage || withLink || withPdf;
   const clickable = !!description || withDetail;
   const withTitle = !!title;
+  // Hotspots that only carry a title + description (no image/link/pdf detail)
+  // expand their label inline instead of opening the side details pane.
+  const inlineExpandable = !withDetail && !!description;
   const hotspotLinkRef = useRef<HTMLAnchorElement | null>(null);
   const hotspotDivRef = useRef<HTMLDivElement | null>(null);
   const titleRef = useRef<HTMLDivElement | null>(null);
   const [shouldFlipTitle, setShouldFlipTitle] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  // Keeps the panel laid out (full width / opacity) while the description
+  // retracts, so closing animates smoothly instead of snapping.
+  const [collapsing, setCollapsing] = useState(false);
+  const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const DefaultIcon = withDetail ? (
+  const clearCollapseTimeout = useCallback(() => {
+    if (collapseTimeoutRef.current !== null) {
+      clearTimeout(collapseTimeoutRef.current);
+      collapseTimeoutRef.current = null;
+    }
+  }, []);
+
+  const collapsePanel = useCallback(() => {
+    setExpanded(wasExpanded => {
+      if (!wasExpanded) {
+        return false;
+      }
+      // Keep the panel laid out while the description retracts.
+      setCollapsing(true);
+      clearCollapseTimeout();
+      // Fallback in case transitionend never fires (e.g. reduced motion)
+      collapseTimeoutRef.current = setTimeout(() => {
+        setCollapsing(false);
+        collapseTimeoutRef.current = null;
+      }, 280);
+      return false;
+    });
+  }, [clearCollapseTimeout]);
+
+  useEffect(() => clearCollapseTimeout, [clearCollapseTimeout]);
+
+  const DefaultIcon =
     type === "damage" ? (
       <WarningIcon className="size-4" />
     ) : (
       <ImageIcon className="size-4" />
-    )
-  ) : (
-    <div className="size-1" />
-  );
+    );
 
   const onClick = () => {
     if (!clickable) {
@@ -105,6 +136,18 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
 
     if (withLink || withPdf) {
       // Navigation is handled by the semantic <a> element
+      return;
+    }
+
+    if (inlineExpandable) {
+      // Toggle the inline description panel instead of opening the side pane
+      if (expanded) {
+        collapsePanel();
+      } else {
+        clearCollapseTimeout();
+        setCollapsing(false);
+        setExpanded(true);
+      }
       return;
     }
 
@@ -126,6 +169,34 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
     if (!over) return;
     setOver(false);
   }, [over, setOver]);
+
+  // Close the inline description panel on Escape or when clicking outside of it
+  useEffect(() => {
+    if (!expanded) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        collapsePanel();
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const rootElement = hotspotDivRef.current;
+      if (rootElement && !rootElement.contains(event.target as Node)) {
+        collapsePanel();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [expanded, collapsePanel]);
 
   // Determine which CSS variable to use based on hotspot type
   const getHotspotColorVariable = useCallback(() => {
@@ -218,9 +289,14 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
     };
   }, [withTitle, title, clickable, extendMode, withDetail]);
 
+  // While collapsing, keep the panel laid out (wide + opaque) so the
+  // description can retract smoothly before reverting to the title pill.
+  const panelMounted = expanded || collapsing;
+
   const sharedClassName = cn(
     "group absolute z-hotspot -translate-x-1/2 -translate-y-1/2 hover:z-hotspot-hover",
-    clickable ? "cursor-pointer" : "cursor-default"
+    clickable ? "cursor-pointer" : "cursor-default",
+    panelMounted && "z-hotspot-hover"
   );
 
   const sharedStyle = {
@@ -233,14 +309,8 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
       <div
         // Hoverable icon
         className={cn(
-          "relative top-px flex shrink-0 items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground",
-          withDetail
-            ? shouldFlipTitle
-              ? "right-[-5px] size-7"
-              : "left-[-5px] size-7"
-            : shouldFlipTitle
-              ? "-right-px size-4"
-              : "-left-px size-4"
+          "relative top-px flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground",
+          shouldFlipTitle ? "right-[-5px]" : "left-[-5px]"
         )}
         style={{ backgroundColor: hotspotColorVariable }}
       >
@@ -251,31 +321,120 @@ const IconHotspot: React.FC<IconHotspotProps> = ({
         />
 
         {/* Use the icon from the config if available. Else, replace it if needed */}
-        <div className={cn(withDetail ? "size-4 [&_*]:size-4" : "size-1")}>
-          {hotspotConfig?.Icon ? hotspotConfig.Icon : DefaultIcon}
-        </div>
+        {(withDetail || hotspotConfig?.Icon) && (
+          <div className="size-4 [&_*]:size-4">
+            {hotspotConfig?.Icon ? hotspotConfig.Icon : DefaultIcon}
+          </div>
+        )}
       </div>
       {withTitle && (
         <div
           className={cn(
-            "absolute bottom-0 -z-10 flex w-max max-w-60 items-center gap-1.5 rounded-t-full bg-foreground py-1.5 text-background transition-[opacity,transform] duration-200 small:max-w-64",
-            extendMode && "large:max-w-72",
-            shouldFlipTitle
-              ? "right-0 rounded-bl-full group-hover:-translate-x-1"
-              : "left-0 rounded-br-full group-hover:translate-x-1",
-            withDetail
-              ? shouldFlipTitle
-                ? "rounded-br-[10px] pl-2.5 pr-6 small:pl-3 small:pr-7"
-                : "rounded-bl-[10px] pl-6 pr-2.5 small:pl-7 small:pr-3"
-              : shouldFlipTitle
-                ? "rounded-br-[8px] pl-2.5 pr-5 small:pl-3 small:pr-6"
-                : "rounded-bl-[8px] pl-5 pr-2.5 small:pl-6 small:pr-3",
-            "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100"
+            "absolute top-[calc(50%+1px)] -z-10 -translate-y-1/2 transition-[opacity,transform] duration-200",
+            panelMounted
+              ? // Expanded: grow to a comfortable reading width, bounded by the media
+                "w-72 max-w-[70vw] small:w-80 large:w-96"
+              : "w-max max-w-60 small:max-w-64",
+            !panelMounted && extendMode && "large:max-w-72",
+            shouldFlipTitle ? "right-0" : "left-0",
+            panelMounted
+              ? "pointer-events-auto opacity-100"
+              : cn(
+                  "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
+                  shouldFlipTitle
+                    ? "group-hover:-translate-x-1"
+                    : "group-hover:translate-x-1"
+                )
           )}
           ref={titleRef}
         >
-          <div className="truncate text-xs font-normal">{title}</div>
-          {clickable && <ArrowRightIcon className="size-5 shrink-0" />}
+          {/* Title row — vertically centered on the hotspot dot */}
+          <div
+            className={cn(
+              "relative flex items-center gap-1.5 bg-foreground py-1.5 text-background",
+              panelMounted
+                ? cn(
+                    "z-10",
+                    // The corner under the hotspot icon matches the circle radius (size-7 = 28px ⇒ 14px)
+                    shouldFlipTitle
+                      ? "rounded-tl-[16px] rounded-tr-[14px] pl-3 pr-6 small:pr-7"
+                      : "rounded-tl-[14px] rounded-tr-[16px] pl-6 pr-3 small:pl-7"
+                  )
+                : cn(
+                    "rounded-t-full",
+                    shouldFlipTitle
+                      ? "rounded-bl-full rounded-br-[10px] pl-2.5 pr-6 small:pl-3 small:pr-7"
+                      : "rounded-bl-[10px] rounded-br-full pl-6 pr-2.5 small:pl-7 small:pr-3"
+                  )
+            )}
+          >
+            <div
+              className={cn(
+                "text-xs font-normal",
+                panelMounted
+                  ? "min-w-0 flex-1 break-words font-medium"
+                  : "truncate"
+              )}
+            >
+              {title}
+            </div>
+            {clickable && (
+              <span
+                className="flex shrink-0"
+                style={
+                  inlineExpandable
+                    ? {
+                        // Two-phase motion: slide right first, then rotate down.
+                        // On collapse the order reverses (rotate up first, then
+                        // slide back) and runs a touch quicker.
+                        translate: expanded ? "5px 0" : "0 0",
+                        rotate: expanded ? "90deg" : "0deg",
+                        transition: expanded
+                          ? "translate 200ms ease, rotate 200ms ease"
+                          : "translate 150ms ease, rotate 150ms ease",
+                        transitionDelay: expanded
+                          ? "0ms, 180ms"
+                          : "120ms, 0ms",
+                      }
+                    : undefined
+                }
+              >
+                <ArrowRightIcon className="size-5 shrink-0" />
+              </span>
+            )}
+          </div>
+
+          {/* Description — grows downward below the title without moving it */}
+          {inlineExpandable && (
+            <div
+              className={cn(
+                "absolute inset-x-0 top-full grid transition-[grid-template-rows] ease-out",
+                expanded ? "grid-rows-[1fr] duration-300" : "grid-rows-[0fr] duration-200"
+              )}
+              onTransitionEnd={event => {
+                // Once the description has fully retracted, revert to the pill
+                if (
+                  event.propertyName === "grid-template-rows" &&
+                  !expanded
+                ) {
+                  clearCollapseTimeout();
+                  setCollapsing(false);
+                }
+              }}
+            >
+              <div className="min-h-0 overflow-hidden">
+                <div
+                  className={cn(
+                    "max-h-[clamp(4rem,40vh,16rem)] overflow-y-auto overscroll-contain whitespace-normal break-words rounded-b-[16px] bg-foreground pb-2 pt-1.5 text-xs font-normal leading-relaxed text-background",
+                    // Align description start with the title text start
+                    shouldFlipTitle ? "pl-3 pr-6 small:pr-7" : "pl-6 pr-3 small:pl-7"
+                  )}
+                >
+                  {description}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </>

--- a/packages/core-ui/src/components/molecules/web_player_elements/NextGenThreeSixtyElement.tsx
+++ b/packages/core-ui/src/components/molecules/web_player_elements/NextGenThreeSixtyElement.tsx
@@ -756,8 +756,10 @@ const NextGenThreeSixtyElementInteractive: React.FC<
               flipped imperatively in showFrame() to track the visible frame
               without triggering React re-renders during spin.
               The wrapper is non-interactive while spinning to avoid hijacking
-              drag/touch gestures. */}
-          {currentItemHotspotsVisible && (
+              drag/touch gestures.
+              Hidden while zooming so hotspots disappear until zoomed back to
+              the original size. */}
+          {currentItemHotspotsVisible && !isZooming && (
             <div
               className={cn(
                 "absolute inset-0 z-[3]",

--- a/packages/core-ui/src/components/molecules/web_player_elements/NextGenThreeSixtyElement.tsx
+++ b/packages/core-ui/src/components/molecules/web_player_elements/NextGenThreeSixtyElement.tsx
@@ -22,8 +22,6 @@ const AUTO_SPIN_DELAY = 750;
 const AUTO_SPIN_DURATION = 1250;
 
 const DRAG_SPIN_PX = 360; // 10px for each image of a 36 images spin
-const SCROLL_SPIN_PX = 480; // 15px for each image of a 36 images spin
-const WHEEL_SPIN_PX = 360; // Match drag sensitivity so trackpad swipe & click-drag feel the same
 
 type NextGenThreeSixtyElementProps = Extract<
   CustomizableItem,
@@ -481,105 +479,9 @@ const NextGenThreeSixtyElementInteractive: React.FC<
     document.addEventListener("mouseup", onStopDragging);
     document.addEventListener("contextmenu", onStopDragging);
 
-    // - Scroll events to update the image thanks to the "invisible scroller"
-
-    const scrollStepPx = SCROLL_SPIN_PX / length;
-
-    const getScrollerWidth = () => scroller.getBoundingClientRect().width;
-
-    const getScrollerCenterPosition = () =>
-      scroller.scrollWidth / 2 - getScrollerWidth() / 2;
-
-    const centerScroller = () => {
-      const target = getScrollerCenterPosition();
-      scroller.scrollLeft = target;
-    };
-
-    // When initializing, we want to center the scroller
-    centerScroller();
-
-    const onScroll = () => {
-      const walk = scroller.scrollLeft - getScrollerCenterPosition();
-
-      if (Math.abs(walk) < scrollStepPx) {
-        return;
-      }
-
-      // XOR operation to reverse the logic
-      if (walk < 0 !== reverse360) {
-        displayNextImage();
-      } else {
-        displayPreviousImage();
-      }
-
-      // We just changed the image, we want to re-center the scroller
-      centerScroller();
-    };
-
-    scroller.addEventListener("scroll", onScroll);
-
-    // - Wheel events (trackpad horizontal swipe & mouse wheel)
-    // NOTE: We handle horizontal wheel explicitly instead of relying on the
-    //       invisible scroller's native scroll-chaining. On macOS trackpads, a
-    //       2-finger horizontal swipe emits `wheel` events whose native scroll
-    //       would otherwise be hijacked by the parent carrousel (or the resting
-    //       hotspot overlay), moving the slide instead of rotating the 360.
-
-    const wheelStepPx = WHEEL_SPIN_PX / length;
-
-    let wheelAccumX = 0;
-    let wheelIdleTimeout: ReturnType<typeof setTimeout> | null = null;
-
-    const clearWheelIdleTimeout = () => {
-      if (wheelIdleTimeout) {
-        clearTimeout(wheelIdleTimeout);
-        wheelIdleTimeout = null;
-      }
-    };
-
-    const onWheel = (e: WheelEvent) => {
-      // Let zoom (ctrl/pinch) and vertical scroll pass through untouched.
-      if (e.ctrlKey || Math.abs(e.deltaX) <= Math.abs(e.deltaY)) {
-        return;
-      }
-
-      // This is a horizontal gesture we want to consume for spinning: prevent
-      // it from bubbling to the parent carrousel or triggering native scroll.
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Cancel any ongoing inertia/demo animation so it does not fight the wheel.
-      cancelAnimation();
-      // No-op when already active (React dedupes identical state updates).
-      setIsSpinActive(true);
-
-      wheelAccumX += e.deltaX;
-
-      while (Math.abs(wheelAccumX) >= wheelStepPx) {
-        // XOR operation to reverse the logic
-        if (wheelAccumX < 0 !== reverse360) {
-          displayNextImage();
-        } else {
-          displayPreviousImage();
-        }
-
-        wheelAccumX -= Math.sign(wheelAccumX) * wheelStepPx;
-      }
-
-      // Trackpads emit their own momentum events; sync the resting frame once
-      // the gesture (including momentum) has settled.
-      clearWheelIdleTimeout();
-      wheelIdleTimeout = setTimeout(() => {
-        wheelAccumX = 0;
-        syncRestingFrame();
-      }, 120);
-    };
-
-    container.addEventListener("wheel", onWheel, { passive: false });
-
-    // - Touch events (only mandatory for Safari mobile)
-    // NOTE: It is due to Safari mobile not allowing to update the scrollLeft property while scrolling
-    //       If the behavior is updated, we can remove this part
+    // - Touch events (drag-to-spin on touch devices)
+    // NOTE: We track clientX deltas and preventDefault to spin without relying
+    //       on native scroll.
 
     let mainTouchId: Touch["identifier"] | null = null;
 
@@ -689,11 +591,6 @@ const NextGenThreeSixtyElementInteractive: React.FC<
       document.removeEventListener("mouseup", onStopDragging);
       document.removeEventListener("contextmenu", onStopDragging);
 
-      scroller.removeEventListener("scroll", onScroll);
-
-      clearWheelIdleTimeout();
-      container.removeEventListener("wheel", onWheel);
-
       scroller.removeEventListener("touchstart", onTouchStart);
       scroller.removeEventListener("touchmove", onTouchMove);
       scroller.removeEventListener("touchend", onTouchEnd);
@@ -730,9 +627,8 @@ const NextGenThreeSixtyElementInteractive: React.FC<
           ))}
         </div>
       )}
-      {/* Scroller is element larger than the image to capture scroll event and then, make the 360 spin */}
-      {/* NOTE: ImageElement is within so that it can capture events first */}
-      <div ref={scrollerRef} className="overflow-x-scroll">
+      {/* Touch-event target for drag-to-spin (mouse drag is handled on the container). */}
+      <div ref={scrollerRef}>
         <div className="sticky left-0 top-0">
           {/* Single flipbook image: src is swapped imperatively during spin (no React re-render).
               Uses the resolved currentSrc URLs that match the browser's srcSet cache. */}
@@ -790,10 +686,6 @@ const NextGenThreeSixtyElementInteractive: React.FC<
             </div>
           )}
         </div>
-        {/* Add space on both sides to allow scrolling */}
-        {/* NOTE: We need the element to have an height, otherwise, Safari will ignore it */}
-        {/*       We need a lot of extra space on the side, otherwise, the 360 will not have inertia on Safari */}
-        <div className="pointer-events-none -mt-px h-px w-[calc(100%+1024px)]" />
       </div>
     </div>
   );

--- a/packages/core-ui/src/components/molecules/web_player_elements/ThreeSixtyElement.tsx
+++ b/packages/core-ui/src/components/molecules/web_player_elements/ThreeSixtyElement.tsx
@@ -21,8 +21,6 @@ const AUTO_SPIN_DELAY = 750;
 const AUTO_SPIN_DURATION = 1250;
 
 const DRAG_SPIN_PX = 360; // 10px for each image of a 36 images spin
-const SCROLL_SPIN_PX = 480; // 15px for each image of a 36 images spin
-const WHEEL_SPIN_PX = 360; // Match drag sensitivity so trackpad swipe & click-drag feel the same
 
 type ThreeSixtyElementProps = Extract<CustomizableItem, { type: "360" }> & {
   itemIndex: number;
@@ -329,87 +327,9 @@ const ThreeSixtyElementInteractive: React.FC<ThreeSixtyElementProps> = ({
     document.addEventListener("mouseup", onStopDragging);
     document.addEventListener("contextmenu", onStopDragging);
 
-    // - Scroll events to update the image thanks to the "invisible scroller"
-
-    const scrollStepPx = SCROLL_SPIN_PX / length;
-
-    const getScrollerWidth = () => scroller.getBoundingClientRect().width;
-
-    const getScrollerCenterPosition = () =>
-      scroller.scrollWidth / 2 - getScrollerWidth() / 2;
-
-    const centerScroller = () => {
-      const target = getScrollerCenterPosition();
-      scroller.scrollLeft = target;
-    };
-
-    // When initializing, we want to center the scroller
-    centerScroller();
-
-    const onScroll = () => {
-      const walk = scroller.scrollLeft - getScrollerCenterPosition();
-
-      if (Math.abs(walk) < scrollStepPx) {
-        return;
-      }
-
-      // XOR operation to reverse the logic
-      if (walk < 0 !== reverse360) {
-        displayNextImage();
-      } else {
-        displayPreviousImage();
-      }
-
-      // We just changed the image, we want to re-center the scroller
-      centerScroller();
-    };
-
-    scroller.addEventListener("scroll", onScroll);
-
-    // - Wheel events (trackpad horizontal swipe & mouse wheel)
-    // NOTE: We handle horizontal wheel explicitly instead of relying on the
-    //       invisible scroller's native scroll-chaining. On macOS trackpads, a
-    //       2-finger horizontal swipe emits `wheel` events whose native scroll
-    //       would otherwise be hijacked by the parent carrousel, moving the
-    //       slide instead of rotating the 360.
-
-    const wheelStepPx = WHEEL_SPIN_PX / length;
-
-    let wheelAccumX = 0;
-
-    const onWheel = (e: WheelEvent) => {
-      // Let zoom (ctrl/pinch) and vertical scroll pass through untouched.
-      if (e.ctrlKey || Math.abs(e.deltaX) <= Math.abs(e.deltaY)) {
-        return;
-      }
-
-      // This is a horizontal gesture we want to consume for spinning: prevent
-      // it from bubbling to the parent carrousel or triggering native scroll.
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Cancel any ongoing inertia/demo animation so it does not fight the wheel.
-      cancelAnimation();
-
-      wheelAccumX += e.deltaX;
-
-      while (Math.abs(wheelAccumX) >= wheelStepPx) {
-        // XOR operation to reverse the logic
-        if (wheelAccumX < 0 !== reverse360) {
-          displayNextImage();
-        } else {
-          displayPreviousImage();
-        }
-
-        wheelAccumX -= Math.sign(wheelAccumX) * wheelStepPx;
-      }
-    };
-
-    container.addEventListener("wheel", onWheel, { passive: false });
-
-    // - Touch events (only mandatory for Safari mobile)
-    // NOTE: It is due to Safari mobile not allowing to update the scrollLeft property while scrolling
-    //       If the behavior is updated, we can remove this part
+    // - Touch events (drag-to-spin on touch devices)
+    // NOTE: We track clientX deltas and preventDefault to spin without relying
+    //       on native scroll.
 
     let mainTouchId: Touch["identifier"] | null = null;
 
@@ -516,10 +436,6 @@ const ThreeSixtyElementInteractive: React.FC<ThreeSixtyElementProps> = ({
       document.removeEventListener("mouseup", onStopDragging);
       document.removeEventListener("contextmenu", onStopDragging);
 
-      scroller.removeEventListener("scroll", onScroll);
-
-      container.removeEventListener("wheel", onWheel);
-
       scroller.removeEventListener("touchstart", onTouchStart);
       scroller.removeEventListener("touchmove", onTouchMove);
       scroller.removeEventListener("touchend", onTouchEnd);
@@ -537,9 +453,8 @@ const ThreeSixtyElementInteractive: React.FC<ThreeSixtyElementProps> = ({
 
   return (
     <div ref={containerRef} style={cursorStyle}>
-      {/* Scroller is element larger than the image to capture scroll event and then, make the 360 spin */}
-      {/* NOTE: ImageElement is within so that it can capture events first */}
-      <div ref={scrollerRef} className="overflow-x-scroll">
+      {/* Touch-event target for drag-to-spin (mouse drag is handled on the container). */}
+      <div ref={scrollerRef}>
         <div className="sticky left-0 top-0">
           {/* Flip book (Ensures image are already in the DOM) */}
           {images.map(image => (
@@ -555,10 +470,6 @@ const ThreeSixtyElementInteractive: React.FC<ThreeSixtyElementProps> = ({
             itemIndex={-1}
           />
         </div>
-        {/* Add space on both sides to allow scrolling */}
-        {/* NOTE: We need the element to have an height, otherwise, Safari will ignore it */}
-        {/*       We need a lot of extra space on the side, otherwise, the 360 will not have inertia on Safari */}
-        <div className="pointer-events-none -mt-px h-px w-[calc(100%+1024px)]" />
       </div>
     </div>
   );

--- a/packages/core-ui/src/const/browser.ts
+++ b/packages/core-ui/src/const/browser.ts
@@ -1,8 +1,33 @@
 export const RESIZE_TRANSITION_DURATION = 500;
 
-// Mirrors the `max-small` breakpoint defined in tailwind.config.ts
-// (BREAKPOINT_SMALL_PORTRAIT = 768, BREAKPOINT_SMALL_LANDSCAPE = 1024).
+// Breakpoint values (in px) shared between Tailwind (tailwind.config.ts) and
+// runtime JS (via window.matchMedia). Single source of truth so the `small`/
+// `large`/`max-small` media queries stay in sync across CSS and behavior.
+export const BREAKPOINT_SMALL_PORTRAIT = 768;
+export const BREAKPOINT_SMALL_LANDSCAPE = 1024;
+export const BREAKPOINT_LARGE = 1280;
+
+// Mirrors the `max-small` breakpoint defined in tailwind.config.ts.
 // Used at runtime (via window.matchMedia) to keep JS behavior in sync with
 // the `max-small:` Tailwind utilities. Comma acts as the "or" combinator.
 export const MAX_SMALL_MEDIA_QUERY =
-  "(orientation: portrait) and (max-width: 767px), (orientation: landscape) and (max-width: 1023px)";
+  `(orientation: portrait) and (max-width: ${BREAKPOINT_SMALL_PORTRAIT - 1}px), ` +
+  `(orientation: landscape) and (max-width: ${BREAKPOINT_SMALL_LANDSCAPE - 1}px)`;
+
+// Mirrors the `small` breakpoint defined in tailwind.config.ts.
+export const SMALL_MEDIA_QUERY =
+  `(orientation: portrait) and (min-width: ${BREAKPOINT_SMALL_PORTRAIT}px), ` +
+  `(orientation: landscape) and (min-width: ${BREAKPOINT_SMALL_LANDSCAPE}px)`;
+
+// Mirrors the `large` breakpoint defined in tailwind.config.ts.
+export const LARGE_MEDIA_QUERY = `(min-width: ${BREAKPOINT_LARGE}px)`;
+
+// Width (in px) the inline hotspot detail panel grows to when expanded, per
+// breakpoint. Mirrors the `w-72 small:w-80 large:w-96` classes in Hotspot.tsx
+// (Tailwind spacing scale: 72 => 288, 80 => 320, 96 => 384). Used at runtime
+// to decide the flip direction so the expanded panel fits within the media.
+export const HOTSPOT_EXPANDED_PANEL_WIDTH = {
+  base: 288,
+  small: 320,
+  large: 384,
+} as const;

--- a/packages/core-ui/tailwind.config.ts
+++ b/packages/core-ui/tailwind.config.ts
@@ -26,6 +26,7 @@ const config: Config = {
   content: ["./src/*/**/*.{ts,tsx}"],
   theme: {
     fontSize: {
+      xxs: ["11px", { lineHeight: "15px" }],
       xs: ["12px", { lineHeight: "16px" }],
       sm: ["14px", { lineHeight: "20px" }],
       base: ["16px", { lineHeight: "24px" }],

--- a/packages/core-ui/tailwind.config.ts
+++ b/packages/core-ui/tailwind.config.ts
@@ -1,6 +1,12 @@
 import type { Config } from "tailwindcss";
 import type { PluginCreator } from "tailwindcss/types/config";
 
+import {
+  BREAKPOINT_LARGE,
+  BREAKPOINT_SMALL_LANDSCAPE,
+  BREAKPOINT_SMALL_PORTRAIT,
+} from "./src/const/browser";
+
 const noScrollbarPlugin: PluginCreator = ({ addUtilities }) =>
   addUtilities({
     ".no-scrollbar": {
@@ -12,10 +18,6 @@ const noScrollbarPlugin: PluginCreator = ({ addUtilities }) =>
       },
     },
   });
-
-const BREAKPOINT_SMALL_PORTRAIT = 768;
-const BREAKPOINT_SMALL_LANDSCAPE = 1024;
-const BREAKPOINT_LARGE = 1280;
 
 const joinMediaQueries = (...queries: string[]) =>
   queries.map(query => `(${query})`).join(" or ");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hotspots with a title and description can now expand inline, showing the description panel directly under the title.
* **Bug Fixes**
  * Inline hotspot panels now dismiss more consistently with **Escape** or by clicking/tapping outside, with smoother collapse timing.
  * The 360° viewer no longer uses page scroll or trackpad/wheel input for spinning, reducing unintended rotations.
* **Chores**
  * Updated the development demo player to load a newer composition source.
  * Improved shared responsive breakpoint sizing for more consistent hotspot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->